### PR TITLE
Remove IsExpired hack

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -30,8 +30,6 @@ type Peer interface {
 	IsReady()
 
 	SetExpiration(int)
-
-	IsExpired() bool
 }
 
 // GetMessageTimeout is a convenience function to get a single message from a

--- a/session.go
+++ b/session.go
@@ -69,7 +69,3 @@ func (s *localPeer) IsReady() {
 func (s *localPeer) SetExpiration(int) {
 	// do nothing - local peers do not expire
 }
-
-func (s *localPeer) IsExpired() bool {
-	return false
-}

--- a/websocket.go
+++ b/websocket.go
@@ -84,12 +84,6 @@ func (ep *websocketPeer) run() {
 		// TODO: use conn.NextMessage() and stream
 		// TODO: do something different based on binary/text frames
 		msgType, b, err := ep.conn.ReadMessage()
-		if ep.IsExpired() {
-			// connection has timed out - close it
-			log.Println("connection timeout reached. Closing to force Re-authentication.")
-			ep.Close()
-			break
-		}
 		if err != nil {
 			if ep.closed {
 				log.Println("peer connection closed")
@@ -128,14 +122,4 @@ func (ep *websocketPeer) SetExpiration(seconds int) {
 	defer ep.writeMutex.Unlock()
 	expiration := time.Now().Add(time.Second * time.Duration(seconds))
 	ep.expiration = &expiration
-}
-
-func (ep *websocketPeer) IsExpired() bool {
-	ep.writeMutex.Lock()
-	defer ep.writeMutex.Unlock()
-	if ep.expiration == nil {
-		// no expiration set. Never expire
-		return false
-	}
-	return time.Now().After(*ep.expiration)
 }


### PR DESCRIPTION
This is no longer necessary as we are enforcing authentication using
tickets in production.  This hack doesn't let the client recover gracefully

Adding a decorator to each procedure call is much cleaner and lets you
use the much cleaner error result which gives the clients more control
over how to retry the calls that fail.